### PR TITLE
Simplify control screen: remove redundancy, clarify button labels

### DIFF
--- a/src/components/control/LeftPane.tsx
+++ b/src/components/control/LeftPane.tsx
@@ -7,20 +7,11 @@ import styles from './LeftPane.module.scss';
 export default function LeftPane() {
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [round, setRound] = useState<'round1'|'round2'|'round3'|'round4'|'sudden_death'|'fast_money'>('round1');
-  const [fmIndex, setFmIndex] = useState<number>(1); // 1..5 for Fast Money
+  const [fmIndex, setFmIndex] = useState<number>(1);
   const [resetOnSwitch, setResetOnSwitch] = useState(true);
-
-  const [countdownEnabled, setCountdownEnabled] = useState(true);
-  const [normalTime, setNormalTime] = useState(30);
-  const [fastMoneyTime, setFastMoneyTime] = useState(20);
 
   const [strikeLimit, setStrikeLimit] = useState(3);
   const [strikes, setStrikes] = useState(0);
-  const [team1Score, setTeam1Score] = useState(0);
-  const [team2Score, setTeam2Score] = useState(0);
-
-  // 🆕 reveal flag for normal rounds (controls main-screen masking)
-  const [revealQ, setRevealQ] = useState<boolean>(false);
 
   const roundNumberMap: Record<typeof round, number> = {
     round1: 1, round2: 2, round3: 3, round4: 4, sudden_death: 5, fast_money: 6,
@@ -29,12 +20,11 @@ export default function LeftPane() {
     1: 'round1', 2: 'round2', 3: 'round3', 4: 'round4', 5: 'sudden_death', 6: 'fast_money',
   };
 
-  // Load active session
   useEffect(() => {
     const loadSession = async () => {
       const { data, error } = await supabase
         .from('game_sessions')
-        .select('*')
+        .select('id, strikes, strike_limit')
         .eq('status', 'active')
         .single();
       if (error) { console.error('Failed to load active session:', error.message); return; }
@@ -42,20 +32,17 @@ export default function LeftPane() {
         setSessionId(data.id);
         setStrikes(data.strikes ?? 0);
         setStrikeLimit(data.strike_limit ?? 3);
-        setTeam1Score(data.team1_score ?? 0);
-        setTeam2Score(data.team2_score ?? 0);
       }
     };
     loadSession();
   }, []);
 
-  // Read current round + reveal flag
   useEffect(() => {
     if (!sessionId) return;
     const getCurrent = async () => {
       const { data, error } = await supabase
         .from('session_questions')
-        .select('round_number, fm_index, reveal_question')
+        .select('round_number, fm_index')
         .eq('session_id', sessionId)
         .eq('is_current', true)
         .single();
@@ -64,22 +51,10 @@ export default function LeftPane() {
         const r = numberToRound[data.round_number];
         setRound(r);
         if (r === 'fast_money' && data.fm_index) setFmIndex(data.fm_index);
-        // Only track reveal flag for normal rounds
-        setRevealQ(!!data.reveal_question && r !== 'fast_money');
       }
     };
     getCurrent();
   }, [sessionId]);
-
-  const updateTeamScore = async (team: 'team1' | 'team2', delta: number) => {
-    if (!sessionId) return;
-    const field = team === 'team1' ? 'team1_score' : 'team2_score';
-    const current = team === 'team1' ? team1Score : team2Score;
-    const newScore = Math.max(0, current + delta);
-    const { error } = await supabase.from('game_sessions').update({ [field]: newScore }).eq('id', sessionId);
-    if (error) { console.error('Score update failed:', error.message); return; }
-    team === 'team1' ? setTeam1Score(newScore) : setTeam2Score(newScore);
-  };
 
   const updateStrikes = async (newCount: number) => {
     if (!sessionId) return;
@@ -93,7 +68,6 @@ export default function LeftPane() {
     const { error: e1 } = await supabase.from('game_sessions').update({ strikes: 0 }).eq('id', sessionId);
     if (!e1) setStrikes(0);
 
-    // find current question_id
     const { data: cur } = await supabase
       .from('session_questions')
       .select('question_id')
@@ -107,31 +81,12 @@ export default function LeftPane() {
     alert('🔁 Round has been reset.');
   };
 
-  // 🆕 Toggle reveal for current normal-round question
-  const setRevealForCurrentNormal = async (show: boolean) => {
-    if (!sessionId) return;
-    // Only affect rounds 1–5
-    const { error } = await supabase
-      .from('session_questions')
-      .update({ reveal_question: show })
-      .eq('session_id', sessionId)
-      .eq('is_current', true)
-      .neq('round_number', 6);
-    if (error) {
-      console.error('Reveal toggle failed:', error.message);
-      return;
-    }
-    setRevealQ(show);
-  };
-
-  // ✅ SWITCH ROUND (handles normal reveal & Fast Money fm_reveal_question default)
   const handleSwitchRound = async () => {
     if (!sessionId) return;
 
     const targetRound = roundNumberMap[round];
     if (!targetRound) return;
 
-    // 1) clear current
     const { error: eUnset } = await supabase
       .from('session_questions')
       .update({ is_current: false })
@@ -139,11 +94,9 @@ export default function LeftPane() {
       .eq('is_current', true);
     if (eUnset) { console.error('Unset current round failed:', eUnset.message); alert('❌ Failed to switch round (unset).'); return; }
 
-    // 2) find the single target row id
     let targetRowId: string | null = null;
 
     if (targetRound === 6) {
-      // Fast Money: choose by fm_index (default to 1 if not set)
       const idx = fmIndex || 1;
       const { data: fmRow, error: eFind } = await supabase
         .from('session_questions')
@@ -156,7 +109,6 @@ export default function LeftPane() {
       if (!fmRow?.id) { alert(`❌ No Fast Money row for index ${idx}.`); return; }
       targetRowId = fmRow.id;
     } else {
-      // Normal round: one row per round_number
       const { data: row, error: eFind } = await supabase
         .from('session_questions')
         .select('id')
@@ -168,7 +120,6 @@ export default function LeftPane() {
       targetRowId = row.id;
     }
 
-    // 3) set that one row current
     const { data: updated, error: eSet } = await supabase
       .from('session_questions')
       .update({ is_current: true })
@@ -177,16 +128,13 @@ export default function LeftPane() {
       .single();
     if (eSet) { console.error('Set new current round failed:', eSet.message); alert('❌ Failed to switch round (set).'); return; }
 
-    // 4) For normal rounds: hide question by default; For FM: show/hide depending on fmIndex
     if (targetRound !== 6) {
       await supabase.from('session_questions').update({ reveal_question: false }).eq('id', targetRowId);
-      setRevealQ(false);
     } else {
-      const fmShouldReveal = fmIndex !== 1; // only FM #1 hidden by default
+      const fmShouldReveal = fmIndex !== 1;
       await supabase.from('session_questions').update({ fm_reveal_question: fmShouldReveal }).eq('id', targetRowId);
     }
 
-    // 5) update session.round label + optionally reset reveals/strikes for the new question
     const roundLabel: Record<number, string> = { 1:'round1',2:'round2',3:'round3',4:'round4',5:'sudden_death',6:'fast_money' };
     await supabase.from('game_sessions').update({ round: roundLabel[targetRound] }).eq('id', sessionId);
 
@@ -200,13 +148,11 @@ export default function LeftPane() {
     alert(`✅ Switched to ${round.replace('_',' ')}${targetRound===6 ? ` (Q${fmIndex})` : ''}`);
   };
 
-  // Reset entire session
   const resetGameSession = async () => {
     if (!sessionId) return;
     const sure = window.confirm('⚠️ Reset entire game session? This will clear scores, answers, and rounds.');
     if (!sure) return;
 
-    // 1. Reset game_sessions fields
     await supabase.from('game_sessions').update({
       team1_score: 0,
       team2_score: 0,
@@ -218,10 +164,8 @@ export default function LeftPane() {
       fm_timer_duration: 20
     }).eq('id', sessionId);
 
-    // 2. Reset all answers reveal flags
     await supabase.from('answers').update({ revealed: false });
 
-    // 3. Reset all fast money responses
     await supabase.from('fast_money_responses').update({
       answer_text: '',
       matched_answer_id: null,
@@ -230,15 +174,11 @@ export default function LeftPane() {
       reveal_points: false
     }).eq('session_id', sessionId);
 
-    // 4. Reset session_questions:
-    //    - all not current
-    //    - FM questions hidden
     await supabase
       .from('session_questions')
       .update({ is_current: false, fm_reveal_question: false, reveal_question: false })
       .eq('session_id', sessionId);
 
-    //    - Round 1 current & hidden by default
     await supabase
       .from('session_questions')
       .update({ is_current: true, reveal_question: false })
@@ -247,7 +187,7 @@ export default function LeftPane() {
 
     setRound('round1');
     setFmIndex(1);
-    setRevealQ(false);
+    setStrikes(0);
     alert('✅ Game session reset!');
   };
 
@@ -265,20 +205,12 @@ export default function LeftPane() {
         <option value="fast_money">Fast Money</option>
       </select>
 
-      {round === 'fast_money' ? (
+      {round === 'fast_money' && (
         <>
           <label>Fast Money Question #</label>
           <select value={fmIndex} onChange={(e) => setFmIndex(Number(e.target.value))}>
             {[1,2,3,4,5].map(n => <option key={n} value={n}>{n}</option>)}
           </select>
-        </>
-      ) : (
-        <>
-          {/* 🆕 normal-round reveal controls */}
-          <div className={styles.revealControls}>
-            <button onClick={() => setRevealForCurrentNormal(true)} disabled={revealQ}>👁️ Reveal Question</button>
-            <button onClick={() => setRevealForCurrentNormal(false)} disabled={!revealQ}>🙈 Hide Question</button>
-          </div>
         </>
       )}
 
@@ -287,15 +219,6 @@ export default function LeftPane() {
         Reset answers & strikes when switching
       </label>
       <button onClick={handleSwitchRound}>🔀 Switch to Selected Round</button>
-
-      <hr />
-
-      <h4>⏱️ Timer Settings</h4>
-      <label><input type="checkbox" checked={countdownEnabled} onChange={() => setCountdownEnabled(!countdownEnabled)} /> Enable Countdown</label>
-      <label>Normal Time (sec):</label>
-      <input type="number" value={normalTime} onChange={(e) => setNormalTime(Number(e.target.value))} />
-      <label>Fast Money Time (sec):</label>
-      <input type="number" value={fastMoneyTime} onChange={(e) => setFastMoneyTime(Number(e.target.value))} />
 
       <hr />
 
@@ -308,17 +231,6 @@ export default function LeftPane() {
       <select value={strikeLimit} onChange={(e) => setStrikeLimit(Number(e.target.value))}>
         <option value={1}>1</option><option value={2}>2</option><option value={3}>3</option>
       </select>
-
-      <hr />
-
-      <h4>📈 Team Scores</h4>
-      <p>Team 1: {team1Score} pts</p>
-      <button onClick={() => updateTeamScore('team1', -5)}>-5</button>
-      <button onClick={() => updateTeamScore('team1', +5)}>+5</button>
-
-      <p>Team 2: {team2Score} pts</p>
-      <button onClick={() => updateTeamScore('team2', -5)}>-5</button>
-      <button onClick={() => updateTeamScore('team2', +5)}>+5</button>
 
       <hr />
       <button className={styles.reset} onClick={handleResetRound}>🔁 Reset Round</button>

--- a/src/components/control/MiddlePane.tsx
+++ b/src/components/control/MiddlePane.tsx
@@ -21,11 +21,6 @@ export default function MiddlePane() {
   const [question, setQuestion] = useState('');
   const [answers, setAnswers] = useState<AnswerRow[]>([]);
 
-  // 🆕 track if current is Fast Money (round 6) and the normal-round reveal flag
-  const [isFastMoney, setIsFastMoney] = useState(false);
-  const [revealQ, setRevealQ] = useState(false);
-  const [currentRowId, setCurrentRowId] = useState<string | null>(null);
-
   const strikeAudio = typeof Audio !== 'undefined' ? new Audio('/sounds/buzzer.mp3') : null;
   const revealDingRef = useRef<HTMLAudioElement | null>(null);
 
@@ -35,15 +30,12 @@ export default function MiddlePane() {
     // Current session_questions row (id, qid, round, reveal flag)
     const { data: sq } = await supabase
       .from('session_questions')
-      .select('id, question_id, round_number, reveal_question')
+      .select('question_id')
       .eq('session_id', sessionId)
       .eq('is_current', true)
       .maybeSingle();
 
     const qid = sq?.question_id as string | undefined;
-    setCurrentRowId(sq?.id ?? null);
-    setIsFastMoney((sq?.round_number ?? 0) === 6);
-    setRevealQ(!!sq?.reveal_question); // (ignored by FM UI, used by normal rounds)
 
     if (!qid) return;
 
@@ -119,24 +111,6 @@ export default function MiddlePane() {
     return () => { void supabase.removeChannel(ch); };
   }, [sessionId]);
 
-  // 🔁 Listen for reveal_question flag changes from elsewhere
-  useEffect(() => {
-    if (!sessionId) return;
-    const ch = supabase
-      .channel(`middle_pane_revealq_${sessionId}`)
-      .on(
-        'postgres_changes',
-        { event: 'UPDATE', schema: 'public', table: 'session_questions', filter: `session_id=eq.${sessionId}` },
-        (payload) => {
-          if (payload.new?.is_current && payload.new?.round_number !== 6) {
-            setRevealQ(!!payload.new.reveal_question);
-          }
-        }
-      )
-      .subscribe();
-    return () => { void supabase.removeChannel(ch); };
-  }, [sessionId]);
-
   // Toggle reveal for one answer (with ding on reveal)
   const toggleReveal = async (id: string, next: boolean) => {
     if (next) {
@@ -174,31 +148,8 @@ export default function MiddlePane() {
     }
   };
 
-  const handleTransferControl = async () => {
-    if (!sessionId) return;
-    const { data } = await supabase
-      .from('game_sessions')
-      .select('active_team')
-      .eq('id', sessionId)
-      .single();
-    const next = data?.active_team === 1 ? 2 : 1;
-    await supabase.from('game_sessions').update({ active_team: next }).eq('id', sessionId);
-  };
-
   const handleIncorrect = async () => {
     strikeAudio?.play();
-  };
-
-  // 🆕 normal-round question reveal/hide (writes to session_questions.reveal_question)
-  const revealQuestionNow = async () => {
-    if (!sessionId || !currentRowId || isFastMoney) return;
-    await supabase.from('session_questions').update({ reveal_question: true }).eq('id', currentRowId);
-    setRevealQ(true);
-  };
-  const hideQuestionNow = async () => {
-    if (!sessionId || !currentRowId || isFastMoney) return;
-    await supabase.from('session_questions').update({ reveal_question: false }).eq('id', currentRowId);
-    setRevealQ(false);
   };
 
   return (
@@ -206,21 +157,6 @@ export default function MiddlePane() {
       <h2>❓ Question Control</h2>
 
       <p className={styles.question}>{question}</p>
-
-      {/* 🆕 Normal-round question reveal controls (not shown for Fast Money) */}
-      {!isFastMoney && (
-        <div className={styles.qControls}>
-          <button className={styles.revealBtn} onClick={revealQuestionNow} disabled={revealQ}>
-            👁️ Reveal Question
-          </button>
-          <button className={styles.hideBtn} onClick={hideQuestionNow} disabled={!revealQ}>
-            🙈 Hide Question
-          </button>
-          <span className={styles.qState}>
-            Status: {revealQ ? 'Visible on Main Screen' : 'Hidden on Main Screen'}
-          </span>
-        </div>
-      )}
 
       {/* Operator always sees answers */}
       <div className={styles.answerList}>
@@ -248,13 +184,10 @@ export default function MiddlePane() {
 
       <div className={styles.bottomActions}>
         <button className={styles.strike} onClick={handleWrongAnswer}>
-          ❌❌ Wrong Answer (X)
+          ❌ Add Strike (X)
         </button>
         <button className={styles.transfer} onClick={handleIncorrect}>
-          ❌ Buzzer
-        </button>
-        <button className={styles.transfer} onClick={handleTransferControl}>
-          🔁 Transfer Control
+          🔔 Play Buzzer Only
         </button>
       </div>
     </div>

--- a/src/components/control/RightPane.tsx
+++ b/src/components/control/RightPane.tsx
@@ -173,16 +173,14 @@ const finalizeRound = async () => {
     <div className={styles.rightPane}>
       <h2>🏆 Team Control</h2>
 
-      <label>{team1Name}</label>
-      <input value={team1Name} onChange={handleTeam1NameChange} />
+      <input placeholder="Team 1 name" value={team1Name} onChange={handleTeam1NameChange} />
       <div className={styles.scoreRow}>
         <button onClick={() => updateScore(1, Math.max(0, team1Score - 5))}>-</button>
         <span>{team1Score} pts</span>
         <button onClick={() => updateScore(1, team1Score + 5)}>+</button>
       </div>
 
-      <label>{team2Name}</label>
-      <input value={team2Name} onChange={handleTeam2NameChange} />
+      <input placeholder="Team 2 name" value={team2Name} onChange={handleTeam2NameChange} />
       <div className={styles.scoreRow}>
         <button onClick={() => updateScore(2, Math.max(0, team2Score - 5))}>-</button>
         <span>{team2Score} pts</span>


### PR DESCRIPTION
- LeftPane: remove dead timer inputs (no DB writes), duplicate reveal/hide question buttons, and duplicate team score controls
- MiddlePane: remove duplicate reveal/hide question section, remove Transfer Control (owned by RightPane); rename "Wrong Answer (X)" → "Add Strike (X)" and "Buzzer" → "Play Buzzer Only" to make their different effects obvious
- RightPane: drop redundant team name labels that echoed the input value; add placeholder text instead